### PR TITLE
Adds more realistic inertias, masses and damping ratios to the robot description

### DIFF
--- a/franka_description/robots/hand.xacro
+++ b/franka_description/robots/hand.xacro
@@ -22,9 +22,9 @@
 
       <!-- for simulation -->
       <inertial>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <mass value="0.68" />
-        <inertia ixx="0.1" ixy="0.0" ixz="0.0" iyy="0.1" iyz="0.0" izz="0.1" />
+        <mass value="0.73" />
+        <origin xyz="0 0.0015244 0.0275912" rpy="0 0 0" />
+        <inertia ixx="0.00278560230025" ixy="0.0" ixz="0.0" iyy="0.000400033405336" iyz="0.0" izz="0.00256378041832" />
       </inertial>
       <!-- end for simulation -->
     </link>
@@ -42,9 +42,9 @@
 
       <!-- for simulation -->
       <inertial>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <mass value="0.01" />
-        <inertia ixx="0.1" ixy="0.0" ixz="0.0" iyy="0.1" iyz="0.0" izz="0.1" />
+        <mass value="0.1" />
+        <origin xyz="0 0.0145644 0.0227941" rpy="0 0 0" />
+        <inertia ixx="3.01220925051e-05" ixy="0.0" ixz="0.0" iyy="2.95873808038e-05" iyz="0.0" izz="6.95125211657e-06" />
       </inertial>
       <!-- end for simulation -->
     </link>
@@ -64,9 +64,9 @@
 
       <!-- for simulation -->
       <inertial>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <mass value="0.01" />
-        <inertia ixx="0.1" ixy="0.0" ixz="0.0" iyy="0.1" iyz="0.0" izz="0.1" />
+        <mass value="0.1" />
+        <origin xyz="0 0.0145644 0.0227941" rpy="0 0 0" />
+        <inertia ixx="3.01220925051e-05" ixy="0.0" ixz="0.0" iyy="2.95873808038e-05" iyz="0.0" izz="6.95125211657e-06" />
       </inertial>
       <!-- end for simulation -->
     </link>

--- a/franka_description/robots/panda.gazebo.xacro
+++ b/franka_description/robots/panda.gazebo.xacro
@@ -7,85 +7,85 @@
         <!-- Link0 -->
         <gazebo reference="${robot_name}_link0">
             <material>Gazebo/Grey</material>
-            <mu1>0.2</mu1>
-            <mu2>0.2</mu2>
+            <mu1>0.61</mu1>
+            <mu2>0.61</mu2>
         </gazebo>
 
         <!-- Link1 -->
         <gazebo reference="${robot_name}_link1">
             <material>Gazebo/White</material>
-            <mu1>0.2</mu1>
-            <mu2>0.2</mu2>
+            <mu1>0.61</mu1>
+            <mu2>0.61</mu2>
         </gazebo>
 
         <!-- Link2 -->
         <gazebo reference="${robot_name}_link2">
             <material>Gazebo/White</material>
-            <mu1>0.2</mu1>
-            <mu2>0.2</mu2>
+            <mu1>0.61</mu1>
+            <mu2>0.61</mu2>
         </gazebo>
 
         <!-- Link3 -->
         <gazebo reference="${robot_name}_link3">
             <material>Gazebo/White</material>
-            <mu1>0.2</mu1>
-            <mu2>0.2</mu2>
+            <mu1>0.61</mu1>
+            <mu2>0.61</mu2>
         </gazebo>
 
         <!-- Link4 -->
         <gazebo reference="${robot_name}_link4">
             <material>Gazebo/White</material>
-            <mu1>0.2</mu1>
-            <mu2>0.2</mu2>
+            <mu1>0.61</mu1>
+            <mu2>0.61</mu2>
         </gazebo>
 
         <!-- Link5 -->
         <gazebo reference="${robot_name}_link5">
             <material>Gazebo/White</material>
-            <mu1>0.2</mu1>
-            <mu2>0.2</mu2>
+            <mu1>0.61</mu1>
+            <mu2>0.61</mu2>
         </gazebo>
 
         <!-- Link6 -->
         <gazebo reference="${robot_name}_link6">
             <material>Gazebo/White</material>
-            <mu1>0.2</mu1>
-            <mu2>0.2</mu2>
+            <mu1>0.61</mu1>
+            <mu2>0.61</mu2>
         </gazebo>
 
         <!-- Link7 -->
         <gazebo reference="${robot_name}_link7">
             <material>Gazebo/Grey</material>
-            <mu1>0.2</mu1>
-            <mu2>0.2</mu2>
+            <mu1>0.61</mu1>
+            <mu2>0.61</mu2>
         </gazebo>
 
         <!-- Link8 -->
         <gazebo reference="${robot_name}_link8">
             <material>Gazebo/Grey</material>
-            <mu1>0.2</mu1>
-            <mu2>0.2</mu2>
+            <mu1>0.61</mu1>
+            <mu2>0.61</mu2>
         </gazebo>
 
         <!-- LinkHand -->
         <gazebo reference="${robot_name}_hand">
             <material>Gazebo/Grey</material>
-            <mu1>0.2</mu1>
-            <mu2>0.2</mu2>
+            <mu1>0.61</mu1>
+            <mu2>0.61</mu2>
         </gazebo>
 
         <!-- LinkRightFinger -->
         <gazebo reference="${robot_name}_rightfinger">
             <material>Gazebo/Grey</material>
-            <mu1>0.2</mu1>
-            <mu2>0.2</mu2>
+            <mu1>0.61</mu1>
+            <mu2>0.61</mu2>
         </gazebo>
 
         <!-- LinkLeftFinger -->
         <gazebo reference="${robot_name}_leftfinger">
             <material>Gazebo/Grey</material>
-            <mu1>0.2</mu1>
-            <mu2>0.2</mu2>
+            <mu1>0.61</mu1>
+            <mu2>0.61</mu2>
         </gazebo>
 
     </xacro:macro>

--- a/franka_description/robots/panda_arm.xacro
+++ b/franka_description/robots/panda_arm.xacro
@@ -35,9 +35,9 @@
 
       <!-- for simulation -->
       <inertial>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <mass value="3.06" />
-        <inertia ixx="0.3" ixy="0.0" ixz="0.0" iyy="0.3" iyz="0.0" izz="0.3" />
+        <mass value="2.92" />
+        <origin xyz="-0.025566 -2.88e-05 0.057332" rpy="0 0 0" />
+        <inertia ixx="0.00782229414331" ixy="-1.56191622996e-05" ixz="-0.00126005738123" iyy="0.0109027971813" iyz="1.08233858202e-05" izz="0.0102355503949" />
       </inertial>
       <!-- end for simulation -->
     </link>
@@ -55,9 +55,9 @@
 
       <!-- for simulation -->
       <inertial>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <mass value="2.34" />
-        <inertia ixx="0.3" ixy="0.0" ixz="0.0" iyy="0.3" iyz="0.0" izz="0.3" />
+        <mass value="2.74" />
+        <origin xyz="0 -0.0324958 -0.0675818" rpy="0 0 0" />
+        <inertia ixx="0.0180416958283" ixy="0.0" ixz="0.0" iyy="0.0159136071891" iyz="0.0046758424612" izz="0.00620690827127" />
       </inertial>
       <!-- end for simulation -->
     </link>
@@ -87,9 +87,9 @@
 
       <!-- for simulation -->
       <inertial>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <mass value="2.36" />
-        <inertia ixx="0.3" ixy="0.0" ixz="0.0" iyy="0.3" iyz="0.0" izz="0.3" />
+        <mass value="2.74" />
+        <origin xyz="0 -0.06861 0.0322285" rpy="0 0 0" />
+        <inertia ixx="0.0182856182281" ixy="0.0" ixz="0.0" iyy="0.00621358421175" iyz="-0.00472844221905" izz="0.0161514346309" />
       </inertial>
       <!-- end for simulation -->
     </link>
@@ -119,9 +119,9 @@
 
       <!-- for simulation -->
       <inertial>
-        <origin xyz="0 0 0" rpy="0 0 0" />
         <mass value="2.38" />
-        <inertia ixx="0.3" ixy="0.0" ixz="0.0" iyy="0.3" iyz="0.0" izz="0.3" />
+        <origin xyz="0.0469893 0.0316374 -0.031704" rpy="0 0 0" />
+        <inertia ixx="0.00771376630908" ixy="-0.00248490625138" ixz="-0.00332147581033" iyy="0.00989108008727" iyz="-0.00217796151484" izz="0.00811723558464" />
       </inertial>
       <!-- end for simulation -->
     </link>
@@ -151,9 +151,9 @@
 
       <!-- for simulation -->
       <inertial>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <mass value="2.43" />
-        <inertia ixx="0.3" ixy="0.0" ixz="0.0" iyy="0.3" iyz="0.0" izz="0.3" />
+        <mass value="2.38" />
+        <origin xyz="-0.0360446 0.0336853 0.031882" rpy="0 0 0" />
+        <inertia ixx="0.00799663881132" ixy="0.00347095570217" ixz="-0.00241222942995" iyy="0.00825390705278" iyz="0.00235774044121" izz="0.0102515004345" />
       </inertial>
       <!-- end for simulation -->
     </link>
@@ -183,9 +183,9 @@
 
       <!-- for simulation -->
       <inertial>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <mass value="3.5" />
-        <inertia ixx="0.3" ixy="0.0" ixz="0.0" iyy="0.3" iyz="0.0" izz="0.3" />
+        <mass value="2.74" />
+        <origin xyz="0 0.0610427 -0.104176" rpy="0 0 0" />
+        <inertia ixx="0.030371374513" ixy="6.50283587108e-07" ixz="-1.05129179916e-05" iyy="0.0288752887402" iyz="-0.00775653445787" izz="0.00444134056164" />
       </inertial>
       <!-- end for simulation -->
     </link>
@@ -215,9 +215,9 @@
 
       <!-- for simulation -->
       <inertial>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <mass value="1.47" />
-        <inertia ixx="0.3" ixy="0.0" ixz="0.0" iyy="0.3" iyz="0.0" izz="0.3" />
+        <mass value="1.55" />
+        <origin xyz="0.0510509 0.009108 0.0106343" rpy="0 0 0" />
+        <inertia ixx="0.00303336450376" ixy="-0.000437276865508" ixz="0.000629257294877" iyy="0.00404479911567" iyz="0.000130472021025" izz="0.00558234286039" />
       </inertial>
       <!-- end for simulation -->
     </link>
@@ -247,9 +247,9 @@
 
       <!-- for simulation -->
       <inertial>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <mass value="0.45" />
-        <inertia ixx="0.3" ixy="0.0" ixz="0.0" iyy="0.3" iyz="0.0" izz="0.3" />
+        <mass value="0.54" />
+        <origin xyz="0.0109695 0.0107965 0.0650411" rpy="0 0 0" />
+        <inertia ixx="0.000888868887021" ixy="-0.00012239074652" ixz="3.98699829666e-05" iyy="0.000888001373233" iyz="-9.33825115206e-05" izz="0.0007176834609" />
       </inertial>
       <!-- end for simulation -->
     </link>
@@ -268,8 +268,8 @@
     <link name="${arm_id}_link8">
       <!-- for simulation -->
       <inertial>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <mass value="0.0" />
+        <mass value="0.001" />
+        <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
         <inertia ixx="0.3" ixy="0.0" ixz="0.0" iyy="0.3" iyz="0.0" izz="0.3" />
       </inertial>
       <!-- end for simulation -->


### PR DESCRIPTION
Currently, the arm is not able to lift itself due to wrongly defined arm and gripper mass/inertial properties. For the effort controller to work we need to add more realistic inertias, masses and joint damping ratios (See issue https://github.com/rickstaa/panda_openai_sim/issues/8).